### PR TITLE
Silence -Wstringop-truncation (#64)

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -70,7 +70,7 @@ static char* find_chars_or_comment(const char* s, const char* chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char* strncpy0(char* dest, const char* src, size_t size)
 {
-    strncpy(dest, src, size);
+    strncpy(dest, src, size - 1);
     dest[size - 1] = '\0';
     return dest;
 }


### PR DESCRIPTION
This pull request fixes -Wstringop-truncation (implemented in GCC 8.1), without changing the behavior of the function.